### PR TITLE
Replace build() with package()

### DIFF
--- a/install-archlinux
+++ b/install-archlinux
@@ -52,7 +52,7 @@ makedepends=()
 conflicts=('starcal-git')
 source=()
 md5sums=()
-build() {
+package() {
     \"\$sourceDir/install\" \"\$pkgdir\" --for-pkg
 }" > PKGBUILD
 


### PR DESCRIPTION
to work with newer versions of Arch
